### PR TITLE
Adds localization context to Shopify queries

### DIFF
--- a/src/getShopifyVariables.ts
+++ b/src/getShopifyVariables.ts
@@ -5,7 +5,7 @@ const getShopifyVariables = (
 ): Required<SanityQueryClientOptions['shopifyVariables']> => {
   return {
     // Defaults taken from https://shopify.dev/beta/hydrogen/getting-started#step-4-make-graphql-changes
-    country: 'US',
+    country: '',
     numProductMetafields: 0,
     numProductVariants: 250,
     numProductMedia: 1,

--- a/src/getShopifyVariables.ts
+++ b/src/getShopifyVariables.ts
@@ -5,6 +5,7 @@ const getShopifyVariables = (
 ): Required<SanityQueryClientOptions['shopifyVariables']> => {
   return {
     // Defaults taken from https://shopify.dev/beta/hydrogen/getting-started#step-4-make-graphql-changes
+    country: 'US',
     numProductMetafields: 0,
     numProductVariants: 250,
     numProductMedia: 1,

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface SanityQueryClientOptions {
   clientConfig?: ClientConfig
 
   shopifyVariables?: {
+    country?: string
     numProductMetafields?: number
     numProductVariants?: number
     numProductMedia?: number

--- a/src/useSanityShopifyProducts.ts
+++ b/src/useSanityShopifyProducts.ts
@@ -8,11 +8,11 @@ interface ProductWithFragment extends ProductToFetch {
   fragment?: string
 }
 
-function getQuery(products: ProductWithFragment[]): string {
+function getQuery(products: ProductWithFragment[], country: string): string {
   // @TODO: replace with final ProductProviderFragment
   return `
   query getProducts(
-    $country: CountryCode
+    ${country ? "$country: CountryCode" : ""}
     $numProductMetafields: Int!
     $numProductVariants: Int!
     $numProductMedia: Int!
@@ -20,7 +20,7 @@ function getQuery(products: ProductWithFragment[]): string {
     $numProductVariantSellingPlanAllocations: Int!
     $numProductSellingPlanGroups: Int!
     $numProductSellingPlans: Int!
-  ) @inContext(country: $country) {
+  ) ${country ? "@inContext(country: $country)" : ""} {
     ${products
       .map(
         (product, index) => `
@@ -68,7 +68,7 @@ const useSanityShopifyProducts = (sanityData: unknown, options: SanityQueryClien
 
   const shouldFetch = productsWithFragments.length > 0
 
-  const finalQuery = shouldFetch ? getQuery(productsWithFragments) : undefined
+  const finalQuery = shouldFetch ? getQuery(productsWithFragments, shopifyVariables?.country) : undefined
 
   const {data: shopifyData} = useSkippableShopQuery<{[key: string]: any}>({
     query: finalQuery,

--- a/src/useSanityShopifyProducts.ts
+++ b/src/useSanityShopifyProducts.ts
@@ -68,7 +68,7 @@ const useSanityShopifyProducts = (sanityData: unknown, options: SanityQueryClien
 
   const shouldFetch = productsWithFragments.length > 0
 
-  const finalQuery = shouldFetch ? getQuery(productsWithFragments, shopifyVariables?.country) : undefined
+  const finalQuery = shouldFetch ? getQuery(productsWithFragments, shopifyVariables?.country || '') : undefined
 
   const {data: shopifyData} = useSkippableShopQuery<{[key: string]: any}>({
     query: finalQuery,

--- a/src/useSanityShopifyProducts.ts
+++ b/src/useSanityShopifyProducts.ts
@@ -12,6 +12,7 @@ function getQuery(products: ProductWithFragment[]): string {
   // @TODO: replace with final ProductProviderFragment
   return `
   query getProducts(
+    $country: CountryCode
     $numProductMetafields: Int!
     $numProductVariants: Int!
     $numProductMedia: Int!
@@ -19,7 +20,7 @@ function getQuery(products: ProductWithFragment[]): string {
     $numProductVariantSellingPlanAllocations: Int!
     $numProductSellingPlanGroups: Int!
     $numProductSellingPlans: Int!
-  ) {
+  ) @inContext(country: $country) {
     ${products
       .map(
         (product, index) => `


### PR DESCRIPTION
In order to ensure the correct currency is returned from Shopify, I've added the `country` variable to `getShopifyVariables`, to `types`, and as `@inContext` to the query  in `useSanityShopifyProducts`.

Fixes #1