### PR TITLE
Add hydrogen query options

### DIFF
--- a/src/useSanityGraphQLQuery.ts
+++ b/src/useSanityGraphQLQuery.ts
@@ -1,5 +1,10 @@
 import {ASTNode} from 'graphql'
-import {useQuery, fetchBuilder, graphqlRequestBody} from '@shopify/hydrogen'
+import {
+  useQuery,
+  fetchBuilder,
+  graphqlRequestBody,
+  HydrogenUseQueryOptions
+} from '@shopify/hydrogen'
 
 import {SanityQueryClientOptions, UseSanityQueryResponse} from './types'
 import useSanityConfig from './useSanityConfig'
@@ -11,6 +16,9 @@ interface UseSanityGraphQLQueryProps extends SanityQueryClientOptions {
 
   /** An object of the variables for the GraphQL query. */
   variables?: {[key: string]: any}
+
+  /** Hydrogen query options */
+  queryOptions?: HydrogenUseQueryOptions
 }
 
 /**
@@ -43,7 +51,7 @@ function useSanityGraphQLQuery<T>({
     fetchBuilder<{data: T}>(url, fetchOptions)
   )
 
-  const shopifyProducts = useSanityShopifyProducts(sanityData?.data, props)
+  const shopifyProducts = useSanityShopifyProducts(sanityData?.data, props, props.queryOptions)
 
   return {
     sanityData: sanityData?.data,

--- a/src/useSanityQuery.ts
+++ b/src/useSanityQuery.ts
@@ -1,4 +1,4 @@
-import {useQuery} from '@shopify/hydrogen'
+import {HydrogenUseQueryOptions, useQuery} from '@shopify/hydrogen'
 
 import {SanityQueryClientOptions, UseSanityQueryResponse} from './types'
 import useSanityConfig from './useSanityConfig'
@@ -10,6 +10,9 @@ interface UseSanityQueryProps extends SanityQueryClientOptions {
 
   /** An object of the variables for the GROQ query. */
   params?: {[key: string]: unknown}
+
+  /** Hydrogen query options */
+  queryOptions?: HydrogenUseQueryOptions
 }
 
 /**
@@ -28,31 +31,35 @@ function useSanityQuery<T>({
     version.startsWith('v') ? version : `v${version}`
   }/data/query/${dataset}`
 
-  const {data: sanityData, error} = useQuery<T>([query, params], async () => {
-    const data = await (
-      await fetch(url, {
-        method: 'POST',
-        headers: token
-          ? {
-              Authorization: `Bearer ${token}`,
-              'Content-Type': 'application/json'
-            }
-          : {
-              'Content-Type': 'application/json'
-            },
-        body: JSON.stringify({
-          query,
-          params
+  const {data: sanityData, error} = useQuery<T>(
+    [query, params],
+    async () => {
+      const data = await (
+        await fetch(url, {
+          method: 'POST',
+          headers: token
+            ? {
+                Authorization: `Bearer ${token}`,
+                'Content-Type': 'application/json'
+              }
+            : {
+                'Content-Type': 'application/json'
+              },
+          body: JSON.stringify({
+            query,
+            params
+          })
         })
-      })
-    ).json()
+      ).json()
 
-    // if (!data.result) {
-    //   throw new Error(data.error?.description || "[hydrogen-plugin-sanity] Couldn't fetch data")
-    // }
+      // if (!data.result) {
+      //   throw new Error(data.error?.description || "[hydrogen-plugin-sanity] Couldn't fetch data")
+      // }
 
-    return data.result
-  })
+      return data.result
+    },
+    props.queryOptions || {}
+  )
 
   const shopifyProducts = useSanityShopifyProducts(sanityData, props)
 

--- a/src/useSanityShopifyProducts.ts
+++ b/src/useSanityShopifyProducts.ts
@@ -1,3 +1,4 @@
+import {HydrogenUseQueryOptions} from '@shopify/hydrogen'
 import extractProductsToFetch, {ProductToFetch} from './extractProductsToFetch'
 import getShopifyVariables from './getShopifyVariables'
 import productFragment from './productFragment'
@@ -35,7 +36,11 @@ function getQuery(products: ProductWithFragment[], country: string): string {
   `
 }
 
-const useSanityShopifyProducts = (sanityData: unknown, options: SanityQueryClientOptions) => {
+const useSanityShopifyProducts = (
+  sanityData: unknown,
+  options: SanityQueryClientOptions,
+  queryOptions?: HydrogenUseQueryOptions
+) => {
   const {getProductGraphQLFragment} = options
   const shopifyVariables = getShopifyVariables(options.shopifyVariables)
   const productsToFetch = extractProductsToFetch(sanityData)
@@ -73,7 +78,8 @@ const useSanityShopifyProducts = (sanityData: unknown, options: SanityQueryClien
 
   const {data: shopifyData} = useSkippableShopQuery<{[key: string]: any}>({
     query: finalQuery,
-    variables: shopifyVariables
+    variables: shopifyVariables,
+    queryOptions
   })
 
   const shopifyProducts = shopifyData

--- a/src/useSkippableShopQuery.ts
+++ b/src/useSkippableShopQuery.ts
@@ -1,5 +1,12 @@
 import {ASTNode} from 'graphql'
-import {isClient, useShop, useQuery, fetchBuilder, graphqlRequestBody} from '@shopify/hydrogen'
+import {
+  isClient,
+  useShop,
+  useQuery,
+  fetchBuilder,
+  graphqlRequestBody,
+  HydrogenUseQueryOptions
+} from '@shopify/hydrogen'
 import {UseShopQueryResponse} from '@shopify/hydrogen/dist/esnext/hooks/useShopQuery/hooks'
 
 /**
@@ -8,13 +15,17 @@ import {UseShopQueryResponse} from '@shopify/hydrogen/dist/esnext/hooks/useShopQ
  */
 export function useSkippableShopQuery<T>({
   query,
-  variables = {}
+  variables = {},
+  queryOptions
 }: {
   /** A string of the GraphQL query. */
   query: ASTNode | string | undefined
 
   /** An object of the variables for the GraphQL query. */
   variables?: {[key: string]: any}
+
+  /** Hydrogen query options */
+  queryOptions?: HydrogenUseQueryOptions
 }): UseShopQueryResponse<T> {
   if (isClient()) {
     throw new Error('Shopify Storefront API requests should only be made from the server.')
@@ -39,7 +50,8 @@ export function useSkippableShopQuery<T>({
       ? fetchBuilder<UseShopQueryResponse<T>>(url, fetchOptions)
       : // If no query, return nothing
         // eslint-disable-next-line
-        async () => ({data: undefined, errors: undefined})
+        async () => ({data: undefined, errors: undefined}),
+    queryOptions
   )
 
   /**


### PR DESCRIPTION
Hydrogen provides a number of [`queryOptions` for `useQuery`](https://shopify.dev/api/hydrogen/hooks/global/usequery#arguments). Some of these options are essential to improve performance, including the `preload` query option that helps eliminate request waterfalls on a Hydrogen page. This PR adds the `queryOptions` parameter to the sanity query hooks, and just passes it through to the underlying hydrogen `useQuery`. 